### PR TITLE
Added a case-insensitive Matcher

### DIFF
--- a/src/StringMatcherInsensitive.js
+++ b/src/StringMatcherInsensitive.js
@@ -1,0 +1,24 @@
+const Match = require('./Match');
+
+/**
+ * Matches case-insensitively. Useful if you don't
+ * want to deal with escaping strings in regexes for
+ * the PatterMatcher.
+ */
+class StringMatcherInsensitive {
+  constructor(type, string) {
+    this.type = type;
+    this.string = string;
+  }
+
+  match(input) {
+    let index = input.toLowerCase().indexOf(this.string.toLowerCase());
+    if (index >= 0) {
+      // return the haystack's case - not the search pattern's case:
+      const matchingString = input.substring(index, index + this.string.length);
+      return new Match(this.type, matchingString, index);
+    }
+  }
+}
+
+module.exports = StringMatcherInsensitive;

--- a/src/index.js
+++ b/src/index.js
@@ -4,4 +4,5 @@ module.exports = {
   Segment: require('./Segment'),
   Segmenter: require('./Segmenter'),
   StringMatcher: require('./StringMatcher'),
+  StringMatcherInsensitive: require('./StringMatcherInsensitive'),
 };

--- a/tests/StringMatcherInsensitive.test.js
+++ b/tests/StringMatcherInsensitive.test.js
@@ -1,0 +1,16 @@
+import {Match, StringMatcherInsensitive} from '../src';
+
+describe('StringMatcherInsensitive', () => {
+  it('matches case insensitively', () => {
+
+    const matcher = new StringMatcherInsensitive('test_type', 'testp@ttern');
+
+    const match = matcher.match('string containing TESTP@ttern with trailing chars');
+
+    expect(match).toBeInstanceOf(Match);
+    expect(match.type).toEqual('test_type');
+    expect(match.match).toEqual('TESTP@ttern');
+    expect(match.first).toEqual(18);
+    expect(match.last).toEqual(29);
+  });
+});


### PR DESCRIPTION
This adds a case-insensitive `Matcher`. 

One could simply use the `PatternMatcher` with a `/pattern/ig` regex - but this way avoids having to deal with escaping the pattern inside the regex.

It returns the original case used in the haystack, not the needle's case.